### PR TITLE
(fix) version mismatch in setup.py and requirement

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,5 +1,5 @@
-num2fawords==1.1
-persian-tools==0.0.10
-urlextract==1.4.0
-nltk==3.6.5
-hazm==0.7.0
+num2fawords>=1.1
+persian-tools>=0.0.10
+urlextract>=1.4.0
+nltk>=3.6.5
+hazm>=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,28 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-     name='parsinorm',  
-     version='0.0.2',
-     packages=['parsinorm'] ,
-     author="HaraAi",
-     author_email="info@hara.ai",
-     description="Persain Text Pre-Proceesing Tool",
-     long_description=long_description,
-   long_description_content_type="text/markdown",
-     url="https://github.com/haraai/ParsiNorm",
-     classifiers=[
-         "Programming Language :: Python :: 3",
-         "License :: OSI Approved :: MIT License",
-         "Operating System :: OS Independent",
-     ],
-     install_requires=['num2fawords==1.1', 'persian-tools==0.0.10', 'urlextract==1.4.0', 'nltk==3.3', 'hazm==0.7.0'],
+    name="parsinorm",
+    version="0.0.2",
+    packages=["parsinorm"] ,
+    author="HaraAi",
+    author_email="info@hara.ai",
+    description="Persain Text Pre-Proceesing Tool",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/haraai/ParsiNorm",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        "num2fawords>=1.1",
+        "persian-tools>=0.0.10",
+        "urlextract>=1.4.0",
+        "nltk>=3.6.5",
+        "hazm>=0.7.0",
+    ],
  )

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="parsinorm",
-    version="0.0.2",
-    packages=["parsinorm"] ,
+    version="0.0.3",
+    packages=["parsinorm"],
     author="HaraAi",
     author_email="info@hara.ai",
     description="Persain Text Pre-Proceesing Tool",
@@ -25,4 +25,4 @@ setuptools.setup(
         "nltk>=3.6.5",
         "hazm>=0.7.0",
     ],
- )
+)


### PR DESCRIPTION
There is a version mismatch in `setup.py` and `requirement.txt`. This PR fixes this issue by making both the same version.

I understand that your package was developed with a specific version of other packages. However, when installed via pip, it did not work properly, resulting in the error:

```python
AttributeError: module 'inspect' has no attribute 'formatargspec'
```

Manually updating the `nltk` package resolved the issue, and updating all other requirements made the module work seamlessly. Therefore, I recommend updating the `setup.py` with `>=` instead of `==` for packages to enhance compatibility.

Please proceed to update the `PyPI` repository with these latest changes.